### PR TITLE
Nbc9 36 boundary conditions

### DIFF
--- a/HOT2000.options
+++ b/HOT2000.options
@@ -3512,9 +3512,8 @@ Whitehorse Wall Options (Code is R28)
 !---------------------------------------------------------------------------------------------
 ! Baseloads 
 ! Note:
-!   DWHR inputs in the DHW section are available for change ONLY if the Base Loads input 
-!   "User Specified Electrical and Water Usage" input is checked. If this is not checked, then
-!   changes made here will be overwritten by the Base Loads user inputs for Water Usage.
+!   If this option is included in the choice file, any existing model baseload inputs WILL
+!   BE OVER-WRITTEN. Only attributes 14 to 18 may have "NA" as an input.
 !
 !---------------------------------------------------------------------------------------------
 *attribute:start

--- a/HOT2000.options
+++ b/HOT2000.options
@@ -3509,6 +3509,79 @@ Whitehorse Wall Options (Code is R28)
 
 *attribute:end
 
+!---------------------------------------------------------------------------------------------
+! Baseloads 
+! Note:
+!   DWHR inputs in the DHW section are available for change ONLY if the Base Loads input 
+!   "User Specified Electrical and Water Usage" input is checked. If this is not checked, then
+!   changes made here will be overwritten by the Base Loads user inputs for Water Usage.
+!
+!---------------------------------------------------------------------------------------------
+*attribute:start
+*attribute:name  = Opt-Baseloads
+*attribute:tag:1 = Opt-H2K-NumAdults                    ! Number of adults occupying the dwelling [Integer]
+*attribute:tag:2 = Opt-H2K-FracAdultsHome               ! Fraction of time adults are home [Real,%]
+*attribute:tag:3 = Opt-H2K-NumChilds                    ! Number of children occupying the dwelling [Integer]
+*attribute:tag:4 = Opt-H2K-FracChildsHome               ! Fraction of time children are home [Real,%]
+*attribute:tag:5 = Opt-H2K-NumInfants                   ! Number of infants occupying the dwelling [Integer]
+*attribute:tag:6 = Opt-H2K-FracInfantsHome              ! Fraction of time infants are home [Real,%]
+*attribute:tag:7 = Opt-H2K-FracToBasement               ! Fraction of internal gains to basement [Real, decimal]
+*attribute:tag:8 = Opt-H2K-Appliances                   ! Electrical appliance consumption [Real, kWh/day]
+*attribute:tag:9 = Opt-H2K-Lighting                     ! Lighting consumption [Real, kWh/day]
+*attribute:tag:10 = Opt-H2K-Other                       ! Other electric consumption [Real, kWh/day]
+*attribute:tag:11 = Opt-H2K-Exterior                    ! Exterior electric consumption [Real, kWh/day]
+*attribute:tag:12 = Opt-H2K-DHWLoad                     ! Hot water load [Real, L/day]
+*attribute:tag:13 = Opt-H2K-DHWTemp                     ! Hot water delivery temperature [Real, degC]
+*attribute:tag:14 = Opt-H2K-FuelStove                   ! Gas stove fuel code. Either "NA", "2" (natural gas), or "4" (propane)
+*attribute:tag:15 = Opt-H2K-StoveUse                    ! Gas stove daily use [Real, kWh/day]
+*attribute:tag:16 = Opt-H2K-FuelDryer                   ! Gas dryer fuel code. Either "NA", "2" (natural gas), or "4" (propane)
+*attribute:tag:17 = Opt-H2K-DryerUse                    ! Gas dryer daily use [Real, kWh/day]
+*attribute:tag:18 = Opt-H2K-DryerLoc                    ! Gas dryer location. Either "NA", "1" (main floor), or "2" (foundation)
+*attribute:default = NA
+
+*option:NA:value:1   = NA
+*option:NA:value:2   = NA
+*option:NA:value:3   = NA
+*option:NA:value:4   = NA
+*option:NA:value:5   = NA
+*option:NA:value:6   = NA
+*option:NA:value:7   = NA
+*option:NA:value:8   = NA
+*option:NA:value:9   = NA
+*option:NA:value:10  = NA
+*option:NA:value:11  = NA
+*option:NA:value:12  = NA
+*option:NA:value:13  = NA
+*option:NA:value:14  = NA
+*option:NA:value:15  = NA
+*option:NA:value:16  = NA
+*option:NA:value:17  = NA
+*option:NA:value:18  = NA
+*option:NA:cost:total = 0
+
+*option:NBC-BaseLoads:value:1   = 2
+*option:NBC-BaseLoads:value:2   = 50
+*option:NBC-BaseLoads:value:3   = 2
+*option:NBC-BaseLoads:value:4   = 50
+*option:NBC-BaseLoads:value:5   = 0
+*option:NBC-BaseLoads:value:6   = 0
+*option:NBC-BaseLoads:value:7   = 0.15
+*option:NBC-BaseLoads:value:8   = 14
+*option:NBC-BaseLoads:value:9   = 3
+*option:NBC-BaseLoads:value:10  = 3
+*option:NBC-BaseLoads:value:11  = 0
+*option:NBC-BaseLoads:value:12  = 225
+*option:NBC-BaseLoads:value:13  = 55
+*option:NBC-BaseLoads:value:14  = NA
+*option:NBC-BaseLoads:value:15  = NA
+*option:NBC-BaseLoads:value:16  = NA
+*option:NBC-BaseLoads:value:17  = NA
+*option:NBC-BaseLoads:value:18  = NA
+*option:NBC-BaseLoads:cost:total = 0
+
+
+*attribute:end
+
 
 !-----------------------------------------------------------------------
 ! Roof pitch. Used for PV calculation. Tag doesn't do anything in ESP-r!


### PR DESCRIPTION
Added a new Opt in substitute-h2k.rb which sets user-defined baseloads in H2K models. Within this Opt the user specifies occupancy, daily electrical appliance and lighting consumption, presence and consumption of gas stoves and dryers, daily hot water consumption, and delivery water temperature. Inputs compliant with 2015 NBC Section 9.36.5 were added to the main options file, and the NBC ruleset in substitute-h2k.rb was updated to include the new Baseloads Opt.