### PR TITLE
Basements and slab/crawlspaces are addressed using different options …

### DIFF
--- a/HOT2000.options
+++ b/HOT2000.options
@@ -2788,9 +2788,123 @@ Whitehorse Wall Options (Code is R28)
 
 *option:NBC_SCB_zone4:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
 *option:NBC_SCB_zone4:value:2 = NA           
-*option:NBC_SCB_zone4:value:3 = NA           
+*option:NBC_SCB_zone4:value:3 = 15.79           
 *option:NBC_SCB_zone4:value:4 = 11.13        
 *option:NBC_SCB_zone4:cost:total = 0
+
+*option:NBC_SOnly_zone4:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone4:value:2 = NA           
+*option:NBC_SOnly_zone4:value:3 = NA           
+*option:NBC_SOnly_zone4:value:4 = 11.13        
+*option:NBC_SOnly_zone4:cost:total = 0
+
+*option:NBC_SCB_zone5_noHRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone5_noHRV:value:2 = NA           
+*option:NBC_SCB_zone5_noHRV:value:3 = 17.49          
+*option:NBC_SCB_zone5_noHRV:value:4 = 11.13        
+*option:NBC_SCB_zone5_noHRV:cost:total = 0
+
+*option:NBC_SCB_zone5_HRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone5_HRV:value:2 = NA           
+*option:NBC_SCB_zone5_HRV:value:3 = 16.87          
+*option:NBC_SCB_zone5_HRV:value:4 = 11.13        
+*option:NBC_SCB_zone5_HRV:cost:total = 0
+
+*option:NBC_SOnly_zone5:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone5:value:2 = NA           
+*option:NBC_SOnly_zone5:value:3 = NA           
+*option:NBC_SOnly_zone5:value:4 = 11.13        
+*option:NBC_SOnly_zone5:cost:total = 0
+
+*option:NBC_SCB_zone6_noHRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone6_noHRV:value:2 = NA           
+*option:NBC_SCB_zone6_noHRV:value:3 = 17.49          
+*option:NBC_SCB_zone6_noHRV:value:4 = 11.13        
+*option:NBC_SCB_zone6_noHRV:cost:total = 0
+
+*option:NBC_SCB_zone6_HRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone6_HRV:value:2 = NA           
+*option:NBC_SCB_zone6_HRV:value:3 = 16.87          
+*option:NBC_SCB_zone6_HRV:value:4 = 11.13        
+*option:NBC_SCB_zone6_HRV:cost:total = 0
+
+*option:NBC_SOnly_zone6:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone6:value:2 = NA           
+*option:NBC_SOnly_zone6:value:3 = NA           
+*option:NBC_SOnly_zone6:value:4 = 11.13        
+*option:NBC_SOnly_zone6:cost:total = 0
+
+*option:NBC_SCB_zone7A_noHRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone7A_noHRV:value:2 = NA           
+*option:NBC_SCB_zone7A_noHRV:value:3 = 17.49          
+*option:NBC_SCB_zone7A_noHRV:value:4 = 21.12    
+*option:NBC_SCB_zone7A_noHRV:cost:total = 0
+
+*option:NBC_SCB_zone7A_HRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone7A_HRV:value:2 = NA           
+*option:NBC_SCB_zone7A_HRV:value:3 = 16.87          
+*option:NBC_SCB_zone7A_HRV:value:4 = 16.13  
+*option:NBC_SCB_zone7A_HRV:cost:total = 0
+
+*option:NBC_SOnly_zone7A_noHRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone7A_noHRV:value:2 = NA           
+*option:NBC_SOnly_zone7A_noHRV:value:3 = NA           
+*option:NBC_SOnly_zone7A_noHRV:value:4 = 21.12         
+*option:NBC_SOnly_zone7A_noHRV:cost:total = 0
+
+*option:NBC_SOnly_zone7A_HRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone7A_HRV:value:2 = NA           
+*option:NBC_SOnly_zone7A_HRV:value:3 = NA           
+*option:NBC_SOnly_zone7A_HRV:value:4 = 16.13        
+*option:NBC_SOnly_zone7A_HRV:cost:total = 0
+
+*option:NBC_SCB_zone7B_noHRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone7B_noHRV:value:2 = NA           
+*option:NBC_SCB_zone7B_noHRV:value:3 = 21.86          
+*option:NBC_SCB_zone7B_noHRV:value:4 = 21.12       
+*option:NBC_SCB_zone7B_noHRV:cost:total = 0
+
+*option:NBC_SCB_zone7B_HRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone7B_HRV:value:2 = NA           
+*option:NBC_SCB_zone7B_HRV:value:3 = 17.49          
+*option:NBC_SCB_zone7B_HRV:value:4 = 16.13       
+*option:NBC_SCB_zone7B_HRV:cost:total = 0
+
+*option:NBC_SOnly_zone7B_noHRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone7B_noHRV:value:2 = NA           
+*option:NBC_SOnly_zone7B_noHRV:value:3 = NA           
+*option:NBC_SOnly_zone7B_noHRV:value:4 = 21.12         
+*option:NBC_SOnly_zone7B_noHRV:cost:total = 0
+
+*option:NBC_SOnly_zone7B_HRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone7B_HRV:value:2 = NA           
+*option:NBC_SOnly_zone7B_HRV:value:3 = NA           
+*option:NBC_SOnly_zone7B_HRV:value:4 = 16.13        
+*option:NBC_SOnly_zone7B_HRV:cost:total = 0
+
+*option:NBC_SCB_zone8_noHRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone8_noHRV:value:2 = NA           
+*option:NBC_SCB_zone8_noHRV:value:3 = 21.86          
+*option:NBC_SCB_zone8_noHRV:value:4 = 26.06      
+*option:NBC_SCB_zone8_noHRV:cost:total = 0
+
+*option:NBC_SCB_zone8_HRV:value:1 = SCB_1_ALL       ! Change all in model (Slabs/Crawls)
+*option:NBC_SCB_zone8_HRV:value:2 = NA           
+*option:NBC_SCB_zone8_HRV:value:3 = 17.49          
+*option:NBC_SCB_zone8_HRV:value:4 = 21.12     
+*option:NBC_SCB_zone8_HRV:cost:total = 0
+
+*option:NBC_SOnly_zone8_noHRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone8_noHRV:value:2 = NA           
+*option:NBC_SOnly_zone8_noHRV:value:3 = NA           
+*option:NBC_SOnly_zone8_noHRV:value:4 = 26.06         
+*option:NBC_SOnly_zone8_noHRV:cost:total = 0
+
+*option:NBC_SOnly_zone8_HRV:value:1 = SCB_1_S         ! Change only the slabs
+*option:NBC_SOnly_zone8_HRV:value:2 = NA           
+*option:NBC_SOnly_zone8_HRV:value:3 = NA           
+*option:NBC_SOnly_zone8_HRV:value:4 = 21.12        
+*option:NBC_SOnly_zone8_HRV:cost:total = 0
 
 *attribute:end
 
@@ -2865,6 +2979,40 @@ Whitehorse Wall Options (Code is R28)
 
 *attribute:end
 
+!-----------------------------------------------------------------------
+! Floor above crawlspace
+!-----------------------------------------------------------------------
+*attribute:start
+
+*attribute:name   = Opt-FloorAboveCrawl 
+*attribute:tag:1  = OPT-H2K-EffRValue   ! User-Specified R-value (Imperial)
+*attribute:default = NA          
+
+*option:NA:value:1 = NA    ! No-change
+*option:NA:cost:total    = 0
+
+!-----------------------------------------------------------------------
+!   NBC 9.36 Baseline
+!-----------------------------------------------------------------------
+*option:NBC_crawlceiling_zone4:value:1 =  26.52
+*option:NBC_crawlceiling_zone4:cost:total    =  0
+
+*option:NBC_crawlceiling_zone5:value:1 =  26.52
+*option:NBC_crawlceiling_zone5:cost:total    =  0
+
+*option:NBC_crawlceiling_zone6:value:1 =  26.52
+*option:NBC_crawlceiling_zone6:cost:total    =  0
+
+*option:NBC_crawlceiling_zone7A:value:1 =  28.50
+*option:NBC_crawlceiling_zone7A:cost:total    =  0
+
+*option:NBC_ecrawlceiling_zone7B:value:1 =  28.50
+*option:NBC_ecrawlceiling_zone7B:cost:total    =  0
+
+*option:NBC_crawlceiling_zone8:value:1 =  28.50
+*option:NBC_crawlceiling_zone8:cost:total    =  0
+
+*attribute:end
 
 !-----------------------------------------------------------------------
 ! HVAC
@@ -3644,25 +3792,25 @@ Whitehorse Wall Options (Code is R28)
 *option:NA:value:18  = NA
 *option:NA:cost:total = 0
 
-*option:NBC-BaseLoads:value:1   = 2
-*option:NBC-BaseLoads:value:2   = 50
-*option:NBC-BaseLoads:value:3   = 2
-*option:NBC-BaseLoads:value:4   = 50
-*option:NBC-BaseLoads:value:5   = 0
-*option:NBC-BaseLoads:value:6   = 0
-*option:NBC-BaseLoads:value:7   = 0.15
-*option:NBC-BaseLoads:value:8   = 14
-*option:NBC-BaseLoads:value:9   = 3
-*option:NBC-BaseLoads:value:10  = 3
-*option:NBC-BaseLoads:value:11  = 0
-*option:NBC-BaseLoads:value:12  = 225
-*option:NBC-BaseLoads:value:13  = 55
-*option:NBC-BaseLoads:value:14  = NA
-*option:NBC-BaseLoads:value:15  = NA
-*option:NBC-BaseLoads:value:16  = NA
-*option:NBC-BaseLoads:value:17  = NA
-*option:NBC-BaseLoads:value:18  = NA
-*option:NBC-BaseLoads:cost:total = 0
+*option:NBC-Baseloads:value:1   = 2
+*option:NBC-Baseloads:value:2   = 50
+*option:NBC-Baseloads:value:3   = 2
+*option:NBC-Baseloads:value:4   = 50
+*option:NBC-Baseloads:value:5   = 0
+*option:NBC-Baseloads:value:6   = 0
+*option:NBC-Baseloads:value:7   = 0.15
+*option:NBC-Baseloads:value:8   = 14
+*option:NBC-Baseloads:value:9   = 3
+*option:NBC-Baseloads:value:10  = 3
+*option:NBC-Baseloads:value:11  = 0
+*option:NBC-Baseloads:value:12  = 225
+*option:NBC-Baseloads:value:13  = 55
+*option:NBC-Baseloads:value:14  = NA
+*option:NBC-Baseloads:value:15  = NA
+*option:NBC-Baseloads:value:16  = NA
+*option:NBC-Baseloads:value:17  = NA
+*option:NBC-Baseloads:value:18  = NA
+*option:NBC-Baseloads:cost:total = 0
 
 
 *attribute:end


### PR DESCRIPTION
…in the NBC rulesets. Basements are updated using Opt-H2KFoundation and slabs and heated crawlspaces are modified using Opt-FoundationSlabCrawl. If a crawlspace is unheated, then the floor above the crawlspace is considered to be an exposed floor. A new option Opt-FloorAboveCrawl was added to modify the thermal resistance of the floor above the crawlspace. A typo was also addressed in the Baseloads implementations in the NBC ruleset. This has been corrected.